### PR TITLE
Sync more data

### DIFF
--- a/nokia.py
+++ b/nokia.py
@@ -200,6 +200,9 @@ class NokiaMeasureGroup(NokiaObject):
         ('diastolic_blood_pressure', 9),
         ('systolic_blood_pressure', 10),
         ('heart_pulse', 11),
+        ('muscle_mass', 76),
+        ('hydration', 77),
+        ('bone_mass', 88),
     )
 
     def __init__(self, data):


### PR DESCRIPTION
This changes the way data is synced to garmin. It syncs all groups between last sync and now. 
Also it sync all additional fields that has garmin in common with nokia. 

The smashrun sync shouldn't be affected. I havn't tested it.