### PR TITLE
Change Nokia URLs to Withings

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Get weight from Nokia Health and update to Garmin Connect or Smashrun.
     - Python 3.X
     - Python libraries: arrow, requests, requests-oauthlib
     
-3. [Register](https://account.health.nokia.com/partner/add_oauth2) an application with Nokia Health and obtain a consumer key and secret.
+3. [Register](https://account.withings.com/partner/add_oauth2) an application with Nokia Health and obtain a consumer key and secret.
     1. logo: the requirements are quite strict, [feel free to use this one](https://github.com/magnific0/nokia-weight-sync/blob/master/logo256w.png)
     1. callback: you can pick anything, but if you want to do the automated authorization (you will be prompted for this), you need to pick the hostname/ip and port carefully. For example http://localhost:8087.
         - localhost: if you run nokia-weight-sync and do the authorization in the browser on the same device. This needs to be replaced by local or public ip/hostname if you run it on a server.

--- a/nokia-weight-sync.py
+++ b/nokia-weight-sync.py
@@ -82,7 +82,7 @@ def setup_nokia( options, config ):
     """
     global nokia_auth_code
     if options.key is None:
-        print("To set a connection with Nokia Health you must have registered an application at https://account.health.nokia.com/partner/add_oauth2 .")
+        print("To set a connection with Nokia Health you must have registered an application at https://account.withings.com/partner/add_oauth2 .")
         options.key = input('Please enter the client id: ')
 
     if options.secret is None:

--- a/nokia.py
+++ b/nokia.py
@@ -5,11 +5,11 @@ Python library for the Nokia Health API
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Nokia Health API
-<https://developer.health.nokia.com/api>
+<http://developer.withings.com/oauth2/>
 
 Uses Oauth 2.0 to authentify. You need to obtain a consumer key
 and consumer secret from Nokia by creating an application
-here: <https://account.health.nokia.com/partner/add_oauth2>
+here: <https://account.withings.com/partner/add_oauth2>
 
 Usage:
 
@@ -60,7 +60,7 @@ class NokiaCredentials(object):
 
 
 class NokiaAuth(object):
-    URL = 'https://account.health.nokia.com'
+    URL = 'https://account.withings.com/'
 
     def __init__(self, client_id, consumer_secret, callback_uri,
                  scope='user.metrics'):
@@ -115,7 +115,7 @@ def ts():
 
 
 class NokiaApi(object):
-    URL = 'https://api.health.nokia.com'
+    URL = 'https://wbsapi.withings.net/'
 
     def __init__(self, credentials):
         self.credentials = credentials


### PR DESCRIPTION
Since Nokia sold its health activities back to Withings, the API and Regstration URLs have to be changed. The Nokia URLs remain available for the moment but they will be disabled on November 30, 2018, as stated in the mail recently sent out by Withings/Nokia. The web services remain the same as before, just the URLs are changing.

The following URLs were changed:
  -  https://api.health.nokia.com to https://wbsapi.withings.net
  -  https://account.health.nokia.com to https://account.withings.com

NB: This PR doesn't change the Nokia* class and variable names to prevent future upstream issues with the [python-nokia](https://github.com/orcasgit/python-nokia) library.