### PR TITLE
Remove trailing slashes from Withings URLs

### DIFF
--- a/nokia.py
+++ b/nokia.py
@@ -60,7 +60,7 @@ class NokiaCredentials(object):
 
 
 class NokiaAuth(object):
-    URL = 'https://account.withings.com/'
+    URL = 'https://account.withings.com'
 
     def __init__(self, client_id, consumer_secret, callback_uri,
                  scope='user.metrics'):
@@ -115,7 +115,7 @@ def ts():
 
 
 class NokiaApi(object):
-    URL = 'https://wbsapi.withings.net/'
+    URL = 'https://wbsapi.withings.net'
 
     def __init__(self, credentials):
         self.credentials = credentials


### PR DESCRIPTION
I noticed the measurements weren't being update since my previous PR got merged. Turned out the Withings endpoints don't play nice with double slashes.

This PR removes the trailing slashes from the URL variables in the NokiaApi and NokiaAuth classes so concatenation of the different endpoints will work again.