### PR TITLE
Calculate BMI

### DIFF
--- a/fit.py
+++ b/fit.py
@@ -204,7 +204,8 @@ class FitEncoder_Weight(FitEncoder):
 
     def write_weight_scale(self, timestamp, weight, percent_fat=None, percent_hydration=None,
                            visceral_fat_mass=None, bone_mass=None, muscle_mass=None, basal_met=None,
-                           active_met=None, physique_rating=None, metabolic_age=None, visceral_fat_rating=None):
+                           active_met=None, physique_rating=None, metabolic_age=None, visceral_fat_rating=None,
+                           bmi=None):
         content = [
             (253, FitBaseType.uint32, self.timestamp(timestamp), 1),
             (0, FitBaseType.uint16, weight, 100),
@@ -218,6 +219,7 @@ class FitEncoder_Weight(FitEncoder):
             (8, FitBaseType.uint8, physique_rating, 1),
             (10, FitBaseType.uint8, metabolic_age, 1),
             (11, FitBaseType.uint8, visceral_fat_rating, 1),
+            (13, FitBaseType.uint16, bmi, 10),
         ]
         fields, values = self._build_content_block(content)
 

--- a/nokia-weight-sync.py
+++ b/nokia-weight-sync.py
@@ -351,6 +351,12 @@ elif command == 'sync':
             save_config()
             sys.exit(0)
 
+        # Get height for BMI calculation
+        height = None
+        m = client_nokia.get_measures(limit=1, meastype=types['height'])
+        if len(m):
+            height = m[0].get_measure(types['height'])
+
         # create fit file
         fit = FitEncoder_Weight()
         fit.write_file_info()
@@ -359,8 +365,13 @@ elif command == 'sync':
         for m in groups:
             weight = m.get_measure(types['weight']);
             if weight:
+                bmi = None
+                if height:
+                    bmi = round(weight / pow(height, 2), 1)
+
                 fit.write_weight_scale(timestamp=m.date.timestamp, weight=weight, percent_fat=m.get_measure(types['fat_ratio']),
-                    percent_hydration=m.get_measure(types['hydration']), bone_mass=m.get_measure(types['bone_mass']), muscle_mass=m.get_measure(types['muscle_mass']))
+                    percent_hydration=m.get_measure(types['hydration']), bone_mass=m.get_measure(types['bone_mass']), muscle_mass=m.get_measure(types['muscle_mass']),
+                    bmi=bmi)
 
         fit.finish()
 


### PR DESCRIPTION
Garmin Connect web doesn't show additional metrics, only weight and Garmin calculated BMI. This is caused by very poor weight scale type detection just by available metrics. There are 3 types of view: base, Atlas scale, Tanita scale. Unfortunately, the Atlas scale view (showing the additional metrics) is detected only by presence of calculated BMI, the Tanita scale by presence of visceral fat. If any of these metrics are missing, it fallbacks to base view (just weight + Garmin calculated BMI).

To show additional metrics from Withings, it's necessary to **fake Atlas scale** by computing the BMI on import. This PR reads user's height from Withings, calculates the BMI and puts it into the FIT. I have to admit that I haven't found the BMI attribute in the offical FIT specification, so it was discovered by experiment.

It happens only on Garmin Connect Web:

![image](https://user-images.githubusercontent.com/414850/52524826-b46e6000-2ca1-11e9-8c59-e4f909b13731.png)

The Garmin Connect mobile doesn't suffer of this problem:

![image](https://user-images.githubusercontent.com/414850/52524891-4e360d00-2ca2-11e9-85ee-93db0503d897.png)

Here is the Garmin Connect  JavaScript code, which detects weight type by available metrics:

https://connect.garmin.com/modern/main/js/pages/weight/WeightPageView.js?bust=4.15.1.0
```javascript
        getSelectWeightType: function() {
            return this.checkTanitaDataExist() ? C.TANITA : this.checkAtlasDataExist() ? C.ATLAS : C.OTHER
        },
        checkTanitaDataExist: function() {
            return t.find(this.weights.weightDataList, function(e) {
                return e.visceralFat
            })
        },
        checkAtlasDataExist: function() {
            return t.find(this.weights.weightDataList, function(e) {
                return e.bmi
            })
        },
```

and, here we can see most metrics is hidden for non-Tanita or non-Atlas scales:

```javascript
           r && this.$("#directBMIClickedTableRow").html(r);
            if (e === C.TANITA || e === C.ATLAS) {
                var s = this.weightChartView.getSelectBodyFat();
                s != "--" && (s = i.personalizeWeightWithoutConvert(s));
                var o = this.weightChartView.getSelectBodyWater();
                o != "--" && (o = i.personalizeWeightWithoutConvert(o));
                var u = this.weightChartView.getSelectBoneMass();
                u != "--" && (u = this.convertToWeightString(u));
...
            } else
                this.$(".js-body-fat-unit").hide(),
                this.$(".js-body-water-unit").hide(),
                this.$(".js-bone-mass-unit").hide(),
```

With provided patch and calculated BMI, the view is switched to show additional (Atlas scale) metrics:

![image](https://user-images.githubusercontent.com/414850/52525051-2b0c5d00-2ca4-11e9-9a14-a3cb5060c896.png)
