### PR TITLE
Fix Garmin signin URLs, synced from cpfair/tapiriik

### DIFF
--- a/garmin.py
+++ b/garmin.py
@@ -158,13 +158,16 @@ class GarminConnect(object):
             # "initialFocus": "true",
             # "locale": "en"
         }
-        
+        headers = {
+            "origin": "https://sso.garmin.com"
+        }
+
         # I may never understand what motivates people to mangle a perfectly good protocol like HTTP in the ways they do...
-        preResp = session.get("https://sso.garmin.com/sso/login", params=params)
+        preResp = session.get("https://sso.garmin.com/sso/signin", params=params)
         if preResp.status_code != 200:
             raise APIException("SSO prestart error %s %s" % (preResp.status_code, preResp.text))
             
-        ssoResp = session.post("https://sso.garmin.com/sso/login", params=params, data=data, allow_redirects=False)
+        ssoResp = session.post("https://sso.garmin.com/sso/signin", headers=headers, params=params, data=data, allow_redirects=False)
         if ssoResp.status_code != 200 or "temporarily unavailable" in ssoResp.text:
             raise APIException("SSO error %s %s" % (ssoResp.status_code, ssoResp.text))
 


### PR DESCRIPTION
Garmin appears to have changed their login routines again.
This changes in this PR updates the URLs to reflect this changes and adds an origin header.

Hat tip to [cpfair/tapiriik](https://github.com/cpfair/tapiriik/blob/master/tapiriik/services/GarminConnect/garminconnect.py) for this change.